### PR TITLE
fix: make browser.js run natively in browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,25 +1,22 @@
 "use strict";
 
 // ref: https://github.com/tc39/proposal-global
-var getGlobal = function () {
-	// the only reliable means to get the global object is
-	// `Function('return this')()`
-	// However, this causes CSP violations in Chrome apps.
-	if (typeof self !== 'undefined') { return self; }
-	if (typeof window !== 'undefined') { return window; }
-	if (typeof global !== 'undefined') { return global; }
-	throw new Error('unable to locate global object');
+var getGlobal = function() {
+    // the only reliable means to get the global object is
+    // `Function('return this')()`
+    // However, this causes CSP violations in Chrome apps.
+    if (typeof self !== 'undefined') { return self; }
+    if (typeof window !== 'undefined') { return window; }
+    if (typeof global !== 'undefined') { return global; }
+    throw new Error('unable to locate global object');
 }
 
 var globalObject = getGlobal();
 
-module.exports = exports = globalObject.fetch;
+export const fetch = globalObject.fetch;
 
-// Needed for TypeScript and Webpack.
-if (globalObject.fetch) {
-	exports.default = globalObject.fetch.bind(globalObject);
-}
+export default globalObject.fetch.bind(globalObject);
 
-exports.Headers = globalObject.Headers;
-exports.Request = globalObject.Request;
-exports.Response = globalObject.Response;
+export const Headers = globalObject.Headers;
+export const Request = globalObject.Request;
+export const Response = globalObject.Response;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the browser.js exports to ESM format to make it actually run in a browser instead of the module.exports approach which requires a build step.

## What is the current behavior?

"xxyy doesn't export a default ..."

## What is the new behavior?

Imports working in the browser natively

## Additional context

Heya! As a part of [trying to get Supabase working without a build step](https://github.com/supabase/supabase-js/issues/671), I ended up coming here to make the browser part of the package run like you would expect a browser.js wrapper of a package to work in the modern year.

